### PR TITLE
Bug/curlies

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -32,23 +32,25 @@ ic_print <- function(loc, parent_ref, deparsed_expression = rlang::missing_arg()
   if (!rlang::is_missing(deparsed_expression)) {
     # We want to print a one-line summary for complex objects like lists and data frames.
     str_res <- ic_peek(value)
-    expression_string <- glue::glue("{{.var {deparsed_expression}}}: {str_res}")
+    expression_string <- glue::glue("{deparsed_expression}: {str_res}")
   }
 
   # We need to check what options are set to decide what to print - whether to include the context
   # or not.
+  #
+  # TODO: It's a bit messy having these multiple calls to `cli_alert_info`. These were introduced
+  #       while fixing https://github.com/lewinfox/icecream/issues/26, when the multiple nested
+  #       glue calls became too complex to unpick easily. It would be nice to construct a single
+  #       perfectly-formatted string and then `cli_alert_info` that, but for now this will do.
   prefix <- getOption("icecream.prefix", "ic|")
-  output <- if (!is.null(expression_string)) {
+  if (!is.null(expression_string)) {
     if (getOption("icecream.always.include.context")) {
-      glue::glue("{context_string} | {expression_string}")
+      cli::cli_alert_info("{prefix} {.var {context_string}} | {expression_string}")
     } else {
-      expression_string
+      cli::cli_alert_info("{prefix} {expression_string}")
     }
   } else {
-    context_string
+    cli::cli_alert_info("{prefix} {.var {context_string}}")
   }
-  output <- paste(prefix, output)
 
-  cli::cli_alert_info(output) # TODO: This is where a custom print/display function would be used
-  invisible(output)
 }

--- a/R/print.R
+++ b/R/print.R
@@ -52,5 +52,4 @@ ic_print <- function(loc, parent_ref, deparsed_expression = rlang::missing_arg()
   } else {
     cli::cli_alert_info("{prefix} {.var {context_string}}")
   }
-
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -254,15 +254,19 @@ data(iris)
 
 ic(iris) # we would like to see header of the data
 
-options(icecream.peeking.function = head,
-        icecream.max.lines = 5)
+options(
+  icecream.peeking.function = head,
+  icecream.max.lines = 5
+)
 
 ic(iris)
 ```
 
 ```{r, include=FALSE}
-options(icecream.peeking.function = old.fun,
-        icecream.max.lines = old.lines)
+options(
+  icecream.peeking.function = old.fun,
+  icecream.max.lines = old.lines
+)
 ```
 
 Note that if `icecream.max.lines` is greater than 1 and summary of an object is longer than 1, the 

--- a/tests/testthat/test-icecream.R
+++ b/tests/testthat/test-icecream.R
@@ -87,3 +87,12 @@ test_that("source file is correctly identified", {
   source(temp, keep.source = TRUE)
   expect_message(f(), regexp = "my_name_is_inigo_montoya")
 })
+
+test_that("invalid glue input is handled cleanly", {
+  expect_message(ic("{"), regexp = "\\{")
+  expect_message(ic("{}"), regexp = "\\{\\}")
+})
+
+test_that("JSON input is handled cleanly", {
+  expect_message(ic("{'a': 1}"), regexp = "\\{'a': 1\\}")
+})


### PR DESCRIPTION
Fixes #26 

Modifies `ic_print()` to handle input that causes invalid inputs to `glue::glue()`. See #26 for examples.

* Modify `ic_print()` to perform selective escaping of curly braces (`{` -> `{{`)
* Add unit tests for the cases identified in #26